### PR TITLE
Added support for PUT requests to the subscribe endpoint

### DIFF
--- a/src/controllers/MailchimpController.php
+++ b/src/controllers/MailchimpController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * A minimal Craft plugin to connect forms to Mailchimp
  *
@@ -17,6 +18,7 @@ use yii\web\Response;
 /*
  * Class MailchimpController
  */
+
 class MailchimpController extends Controller
 {
     // Protected Properties
@@ -24,15 +26,20 @@ class MailchimpController extends Controller
 
     protected int|bool|array $allowAnonymous = true;
 
+    protected const ALLOWED_METHODS = ['POST', 'PUT'];
+
     // Public Methods
     // =========================================================================
 
     public function actionSubscribe(): Response
     {
-        if ($_POST) {
-            return $this->asJson(SimpleMailchimp::getInstance()->smcService->subscribe($_POST));
+        if (in_array($this->request->method, self::ALLOWED_METHODS)) {
+            $params = $this->request->getBodyParams();
+
+            return $this->asJson(SimpleMailchimp::getInstance()->smcService->subscribe($params, $this->request->isPut));
         }
 
-        return $this->asJson(['success' => false, 'msg' => 'Direct access not allowed']);
+        $this->response->setStatusCode(405);
+        return $this->asJson(['success' => false, 'msg' => 'Method not allowed']);
     }
 }


### PR DESCRIPTION
For people to re-subscribe, put requests need to be allowed. Mailchimp will also throw errors when the email already exist, this way it is handled nicely with an upsert.